### PR TITLE
Update Options input type & Export Options type cho TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vn-badwords",
-  "version": "1.1.6",
+  "version": "1.1.7-fix",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vn-badwords",
-      "version": "1.1.6",
+      "version": "1.1.7-fix",
       "license": "ISC",
       "devDependencies": {
         "@vitest/coverage-c8": "^0.29.7",

--- a/src/lib/blacklist.test.ts
+++ b/src/lib/blacklist.test.ts
@@ -19,9 +19,16 @@ describe('Detect bad words', () => {
 
         it('Should run with extra blacklist if provided', () => {
             const result = badWords('alo alo', {
-                blackList: ['alo'],
+                blackList: (defaultList) => [...defaultList, 'alo'],
             });
             expect(result).toEqual('*** ***');
+        });
+
+        it('Should check with a custom blacklist', () => {
+            const result = badWords('alo dcm', {
+                blackList: () => ['alo'],
+            });
+            expect(result).toEqual('*** dcm');
         });
 
         it('Should replace bad words with the replacement provided in options', () => {

--- a/src/lib/blacklist.ts
+++ b/src/lib/blacklist.ts
@@ -1,4 +1,4 @@
-import blackList from './lang/vi.json';
+import DEFAULT_BLACKLIST from './lang/vi.json';
 
 type DefinitelyString<T> = Extract<T, string> extends never
   ? string
@@ -65,7 +65,7 @@ export type BadWordsCallback = (badWordsMatch: string[], length: number) => unkn
 type BadWords = boolean | string;
 
 const DEFAULT_OPTIONS: BadWordsOptions = {
-    blackList: () => blackList,
+    blackList: () => DEFAULT_BLACKLIST,
     replacement: '*',
     validate: false,
 };
@@ -74,14 +74,14 @@ function createConfig(extraConfig?: string | Partial<BadWordsOptions>): BadWords
     if (!extraConfig) {
         return {
           ...DEFAULT_OPTIONS,
-          blackList,
+          blackList: DEFAULT_BLACKLIST,
         };
     }
 
     if (isString(extraConfig)) {
         return {
             ...DEFAULT_OPTIONS,
-            blackList,
+            blackList: DEFAULT_BLACKLIST,
             replacement: extraConfig,
         };
     }
@@ -90,10 +90,10 @@ function createConfig(extraConfig?: string | Partial<BadWordsOptions>): BadWords
 
    let customBlackList =
       extraBlacklist && isFunc(extraBlacklist)
-        ? extraBlacklist(blackList)
+        ? extraBlacklist(DEFAULT_BLACKLIST)
         : [];
    if (!isArray(customBlackList) || customBlackList.length <= 0) {
-     customBlackList = blackList;
+     customBlackList = DEFAULT_BLACKLIST;
    }
   
    return {
@@ -133,4 +133,4 @@ export function badWords(input: string, options?: string | Partial<BadWordsOptio
     return strReplace;
 }
 
-export { blackList };
+export { DEFAULT_BLACKLIST as blackList };


### PR DESCRIPTION
- #12 đã chuyển options.blackList từ 1 array thành 1 callback function nhưng không update option type. Mình đã update lại cho đúng.
  - Đồng thời mình cũng tạo ra 1 type mới cho Config, để dùng để chạy những chức năng kế tiếp sau khi tạo được config.
  - Update unit test cho các tình huống trên.
- Đổi tên biến `blackList` thành `DEFAULT_BLACKLIST`, để phân biệt nó với các black list còn lại.
  - Cái này không ảnh hưởng tới export, chỉ trong lib code thôi.
- Export luôn type của Option và Callback để sử dụng trong TypeScript.